### PR TITLE
In case of 400 error, stop polling and throw exception

### DIFF
--- a/src/main/java/io/perfana/client/PerfanaClient.java
+++ b/src/main/java/io/perfana/client/PerfanaClient.java
@@ -251,10 +251,14 @@ public final class PerfanaClient implements PerfanaCaller {
                     assertionsAvailable = true;
                     break;
                 } else {
-                    String message = (responseBody == null) ? response.message() : responseBody.string();
-                    logger.info(
+                    if (response.code() == 400) {
+                        throw new PerfanaClientException(responseBody.string());
+                    } else {
+                        String message = (responseBody == null) ? response.message() : responseBody.string();
+                        logger.info(
                             String.format("failed to retrieve assertions for url [%s] code [%d] retry [%d/%d] %s",
                             url, response.code(), retryCount, settings.getRetryMaxCount(), message));
+                    }    
                 }
             } catch (IOException e) {
                 throw new PerfanaClientException(String.format("unable to retrieve assertions for url [%s]", url), e);


### PR DESCRIPTION
Perfana will return a 400 with "No KPI's have been specified for this test run! Set assertResults property to false or create a KPI"