### PR TITLE
Optionally set a different classloader for loading event provider classes

### DIFF
--- a/src/main/java/io/perfana/event/PerfanaEventProvider.java
+++ b/src/main/java/io/perfana/event/PerfanaEventProvider.java
@@ -20,8 +20,8 @@ public class PerfanaEventProvider implements PerfanaEventBroadcaster {
         this.logger = logger;
     }
 
-    public static PerfanaEventProvider createInstanceWithEventsFromClasspath(PerfanaClientLogger logger) {
-        ServiceLoader<PerfanaEvent> perfanaEventLoader = ServiceLoader.load(PerfanaEvent.class);
+    public static PerfanaEventProvider createInstanceWithEventsFromClasspath(PerfanaClientLogger logger, ClassLoader classLoader) {
+        ServiceLoader<PerfanaEvent> perfanaEventLoader = ServiceLoader.load(PerfanaEvent.class, classLoader);
         // java 9+: List<PerfanaEvent> events = perfanaEventLoader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList());
         List<PerfanaEvent> events = new ArrayList<>();
         for (PerfanaEvent event : perfanaEventLoader) {

--- a/src/main/java/io/perfana/event/generator/EventScheduleGeneratorProvider.java
+++ b/src/main/java/io/perfana/event/generator/EventScheduleGeneratorProvider.java
@@ -18,8 +18,8 @@ public class EventScheduleGeneratorProvider {
         this.logger = logger;
     }
 
-    public static EventScheduleGeneratorProvider createInstanceFromClasspath(PerfanaClientLogger logger) {
-        ServiceLoader<EventScheduleGenerator> generatorLoader = ServiceLoader.load(EventScheduleGenerator.class);
+    public static EventScheduleGeneratorProvider createInstanceFromClasspath(PerfanaClientLogger logger, ClassLoader classLoader) {
+        ServiceLoader<EventScheduleGenerator> generatorLoader = ServiceLoader.load(EventScheduleGenerator.class, classLoader);
         // java 9+: List<PerfanaEvent> generators = perfanaEventLoader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList());
         Map<String, EventScheduleGenerator> generators = new HashMap<>();
         for (EventScheduleGenerator generator : generatorLoader) {


### PR DESCRIPTION
By default the classloader from the current thread is used to load event providers.

However this may not contain the required runtime classes.

For example when executing the perfana client from a gradle plugin the thread classpath is limited to plugin classes, and does not contain classes from the project context, such as the custom event providers used in the project.