### PR TITLE
perfana-java-client jar can be used as a plugin for event-scheduler 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.perfana</groupId>
     <artifactId>perfana-java-client</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8-SNAPSHOT</version>
     <description>Perfana java client for integrating performance test tools</description>
     <packaging>jar</packaging>
 
@@ -94,6 +94,7 @@
                 <version>${plexus-utils.version}</version>
             </dependency>
         </dependencies>
+
     </dependencyManagement>
 
     <dependencies>
@@ -132,6 +133,11 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>2.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.stokpop</groupId>
+            <artifactId>event-scheduler</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/perfana/event2/EventPerfanaClientLogger.java
+++ b/src/main/java/io/perfana/event2/EventPerfanaClientLogger.java
@@ -1,0 +1,43 @@
+package io.perfana.event2;
+
+import io.perfana.client.api.PerfanaClientLogger;
+import nl.stokpop.eventscheduler.api.EventLogger;
+import nl.stokpop.eventscheduler.log.EventLoggerStdOut;
+
+public class EventPerfanaClientLogger implements PerfanaClientLogger {
+
+    private EventLogger eventLogger;
+
+    public EventPerfanaClientLogger() {
+        this(null);
+    }
+
+    public EventPerfanaClientLogger(EventLogger logger) {
+        this.eventLogger = logger == null ? EventLoggerStdOut.INSTANCE : logger;
+    }
+
+    @Override
+    public void info(String message) {
+        this.eventLogger.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        this.eventLogger.warn(message);
+    }
+
+    @Override
+    public void error(String message) {
+        this.eventLogger.error(message);
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
+        this.eventLogger.error(message, throwable);
+    }
+
+    @Override
+    public void debug(String message) {
+        this.eventLogger.debug(message);
+    }
+}

--- a/src/main/java/io/perfana/event2/PerfanaEvent2.java
+++ b/src/main/java/io/perfana/event2/PerfanaEvent2.java
@@ -1,0 +1,85 @@
+package io.perfana.event2;
+
+import io.perfana.client.PerfanaClient;
+import io.perfana.client.PerfanaClientBuilder;
+import io.perfana.client.api.PerfanaConnectionSettings;
+import io.perfana.client.api.PerfanaConnectionSettingsBuilder;
+import io.perfana.client.api.TestContextBuilder;
+import io.perfana.client.exception.PerfanaAssertionsAreFalse;
+import io.perfana.client.exception.PerfanaClientException;
+import nl.stokpop.eventscheduler.api.*;
+
+public class PerfanaEvent2 extends EventAdapter {
+
+    private final String CLASSNAME = PerfanaEvent2.class.getName();
+
+    private PerfanaClient perfanaClient;
+
+    // save some state to do the status check
+    private EventCheck eventCheck;
+
+    PerfanaEvent2(String name, TestContext context, EventProperties properties, EventLogger logger) {
+        super(name, context, properties, logger);
+        this.eventCheck = new EventCheck(eventName, CLASSNAME, EventStatus.UNKNOWN, "No known result yet. Try again some time later.");
+    }
+
+    @Override
+    public void beforeTest() {
+
+        PerfanaConnectionSettings settings = new PerfanaConnectionSettingsBuilder()
+                .setPerfanaUrl(eventProperties.getPropertyOrDefault("perfanaUrl", "http://localhost:8888"))
+                .build();
+
+        io.perfana.client.api.TestContext perfanaTestContext = new TestContextBuilder()
+                .setVariables(testContext.getVariables())
+                .setTags(testContext.getTags())
+                .setAnnotations(testContext.getAnnotations())
+                .setApplication(testContext.getApplication())
+                .setApplicationRelease(testContext.getApplicationRelease())
+                .setCIBuildResultsUrl(testContext.getCIBuildResultsUrl())
+                .setConstantLoadTime(testContext.getPlannedDuration())
+                .setRampupTime(testContext.getRampupTime())
+                .setTestEnvironment(testContext.getTestEnvironment())
+                .setTestRunId(testContext.getTestRunId())
+                .setTestType(testContext.getTestType()).build();
+
+        PerfanaClientBuilder builder = new PerfanaClientBuilder()
+                .setLogger(new EventPerfanaClientLogger(logger))
+                .setTestContext(perfanaTestContext)
+                .setPerfanaConnectionSettings(settings)
+                .setAssertResultsEnabled(Boolean.valueOf(eventProperties.getPropertyOrDefault("assertResultsEnabled", "true")));
+                // this is not needed, events are already in event-scheduler! .setCustomEvents(eventProperties.getPropertyOrDefault("eventScheduleScript", ""));
+
+        perfanaClient = builder.build();
+
+        perfanaClient.startSession();
+    }
+
+    @Override
+    public void afterTest() {
+        try {
+            perfanaClient.stopSession();
+        } catch (PerfanaClientException e) {
+            logger.error("Stop Perfana session call failed.", e);
+        } catch (PerfanaAssertionsAreFalse perfanaAssertionsAreFalse) {
+            eventCheck = new EventCheck(eventName, CLASSNAME, EventStatus.FAILURE, perfanaAssertionsAreFalse.getMessage());
+        }
+        eventCheck = new EventCheck(eventName, CLASSNAME, EventStatus.SUCCESS, "All ok!");
+    }
+
+    @Override
+    public void abortTest() {
+        perfanaClient.abortSession();
+        this.eventCheck = new EventCheck(eventName, CLASSNAME, EventStatus.ABORTED, "Test run is aborted.");
+    }
+
+    @Override
+    public EventCheck check() {
+        return eventCheck;
+    }
+
+    @Override
+    public void keepAlive() {
+        logger.info("Keep alive called, no implementation in PerfanaEvent2 as of yet.");
+    }
+}

--- a/src/main/java/io/perfana/event2/PerfanaEvent2Factory.java
+++ b/src/main/java/io/perfana/event2/PerfanaEvent2Factory.java
@@ -1,0 +1,11 @@
+package io.perfana.event2;
+
+import nl.stokpop.eventscheduler.api.*;
+
+public class PerfanaEvent2Factory implements EventFactory {
+
+    @Override
+    public Event create(String eventName, TestContext testContext, EventProperties eventProperties, EventLogger logger) {
+        return new PerfanaEvent2(eventName, testContext, eventProperties, logger);
+    }
+}

--- a/src/main/resources/META-INF/services/nl.stokpop.eventscheduler.api.EventFactory
+++ b/src/main/resources/META-INF/services/nl.stokpop.eventscheduler.api.EventFactory
@@ -1,0 +1,1 @@
+io.perfana.event2.PerfanaEvent2Factory


### PR DESCRIPTION
this pr makes the perfana-java-client useable as a plugin to the event-scheduler (https://github.com/stokpop/event-scheduler) and related plugin (https://github.com/stokpop/events-gatling-maven-plugin)

it can be used as follows (snippet from a gatling load test pom.xml):

<plugins>
    <plugin>
        <groupId>nl.stokpop</groupId>
        <artifactId>events-gatling-maven-plugin</artifactId>
        <configuration>
            ...
            <eventApplication>MyApplication</eventApplication>
            <eventProductName>MyProduct</eventProductName>
            <eventProductRelease>1.0.4</eventProductRelease>
            <eventTestType>${testType}</eventTestType>
            <eventTestRunId>${testRunId}</eventTestRunId>
            <eventRampupTimeInSeconds>${rampupTimeInSeconds}</eventRampupTimeInSeconds>
            <eventConstantLoadTimeInSeconds>${constantLoadTimeInSeconds}</eventConstantLoadTimeInSeconds>
            <eventTestEnvironment>${testEnvironment}</eventTestEnvironment>

            <eventProperties>
                <MyPerfanaClient>
                    <eventFactory>io.perfana.event2.PerfanaEvent2Factory</eventFactory>
                    <perfanaUrl>https://perfana.example.org</perfanaUrl>
                </MyPerfanaClient>
            </eventProperties>
           
            <dependencies>
                <dependency>
                    <groupId>nl.stokpop</groupId>
                    <artifactId>test-events-hello-world</artifactId>
                    <version>1.0.1</version>
                </dependency
                <dependency>
                    <groupId>io.perfana</groupId>
                    <artifactId>perfana-java-client</artifactId>
                    <version>x.y.z</version>
                </dependency>
        </dependencies>
    <plugin>
<plugins>