### PR TITLE
use event description "manually aborted"

### DIFF
--- a/src/main/java/io/perfana/event/PerfanaEvent.java
+++ b/src/main/java/io/perfana/event/PerfanaEvent.java
@@ -101,7 +101,7 @@ public class PerfanaEvent extends EventAdapter {
     @Override
     public void abortTest() {
         String eventTitle = "Test aborted";
-        String eventDescription = abortDetailMessage == null ? "" : abortDetailMessage;
+        String eventDescription = abortDetailMessage == null ? "manually aborted" : abortDetailMessage;
         perfanaClient.callPerfanaEvent(perfanaTestContext, eventTitle, eventDescription);
         this.eventCheck = new EventCheck(eventName, CLASSNAME, EventStatus.ABORTED, eventDescription);
     }


### PR DESCRIPTION
if no detail message from killswitch or abort exception: use event description "manually aborted"